### PR TITLE
Replicate __builtin_unreachable() on MSVC with __assume(false)

### DIFF
--- a/include/tao/pq/field.hpp
+++ b/include/tao/pq/field.hpp
@@ -38,7 +38,11 @@ namespace tao::pq
          -> std::enable_if_t< result_traits_size< T > != 1, T >
       {
          static_assert( !std::is_same_v< T, T >, "tao::pq::result_traits<T>::size does not yield exactly one column for T, which is required for field access" );
+#ifdef _WIN32
+         __assume(false);
+#else
          __builtin_unreachable();
+#endif
       }
 
       template< typename T >

--- a/include/tao/pq/row.hpp
+++ b/include/tao/pq/row.hpp
@@ -57,7 +57,11 @@ namespace tao::pq
          -> std::enable_if_t< result_traits_size< T > == 0, T >
       {
          static_assert( !std::is_same< T, T >::value, "tao::pq::result_traits<T>::size yields zero" );
+#ifdef _WIN32
+         __assume(false);
+#else
          __builtin_unreachable();
+#endif
       }
 
       template< typename T >


### PR DESCRIPTION
This PR adds a minor change for MSVC: I could not find a definition of `__builtin_unreachable()` on MSVC. Supposedly the equivalent for the Microsoft compiler is to use `__assume(false)`. Tested with Visual Studio 2019 x64 using the Microsfot and the ClangCL compilers.