### PR TITLE
Documented installation process

### DIFF
--- a/doc/Installing.md
+++ b/doc/Installing.md
@@ -1,0 +1,103 @@
+# Installing
+
+The Taopq project is a library, different from other Taocpp projects, this one needs to be built and requires PostgreSQL library installed. On this section will visit some ways how to install Taopq properly. We will use CMake for building, but it does not mean that is the only way.
+
+## Using Conan package manager
+
+[Conan](https://conan.io) is a dedicated C/C++ package manager which supports many popular projects, including Taocpp.
+To install install Taopq using Conan, first we need to create a file named ``conanfile.txt`` which points Taopq as our dependency:
+
+
+```ini
+[requires]
+taocpp-taopq/20210727
+
+[generators]
+cmake_find_package
+```
+
+To check which the latest Taopq packaged version available for download, visit: https://conan.io/center/taocpp-taopq.
+Or, you can simply search by using the Conan client command:
+
+    conan search -r conancenter taocpp-taopq
+
+Now, to install Taopq and its dependencies, run:
+
+    conan install .
+
+Where `.` indicated the folder where `conanfile.txt` is installed. You also can pass the file path if you prefer.
+
+However, if you do not want to keep a new file, you can simply install the package directly, the result will be the same:
+
+    conan install -r conan-center taocpp-taopq/20200222@ -g cmake_find_package
+
+Conan will generate the files `FindPostgreSQL.cmake`, `FindZLIB.cmake` and `Findtaopq.cmake` which can be linked directly our `CMakeLists.txt` file:
+
+
+```cmake
+cmake_minimum_required(VERSION 3.1)
+project(example CXX)
+
+find_package(ZLIB REQUIRED)
+find_package(PostgreSQL REQUIRED)
+find_package(taopq REQUIRED)
+
+add_library(example main.cpp)
+target_link_libraries(example taocpp::taopq)
+set_target_properties(example PROPERTIES CXX_STANDARD 17)
+```
+
+Now, we just need to configure and build our project:
+
+    cmake .
+    cmake --build .
+
+Done, your project should be built correctly and linked to Taopq, libpq and libz.
+
+
+## Using CMake
+
+Since CMake 3.11, the feature [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) can used to download and build project dependencies.
+This mechanism makes our development much easier, but is lacks in terms of reproducibility, so be careful if you are using it for production. Also, we will use `FetchContent_MakeAvailable` which is available since CMake 3.14:
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(example CXX)
+
+include(FetchContent)
+find_package(PostgreSQL REQUIRED)
+
+FetchContent_Declare(
+   taocpp-taopq
+   GIT_REPOSITORY https://github.com/taocpp/taopq
+   GIT_TAG main
+)
+FetchContent_MakeAvailable(taocpp-taopq)
+
+
+add_library(example main.cpp)
+target_link_libraries(example taocpp::taopq)
+set_property(TARGET example PROPERTY CXX_STANDARD 17)
+```
+
+Now, we just need to execute CMake as usual:
+
+    cmake .
+    cmake --build .
+
+The CMake client will download Taopq source files based on the `main` branch, but is highly recommended using a commit to keep the reproducibility.
+Besides that, PostgreSQL (libpq) is a pre-requirement. You can extend your CMake to download and build libpq too, or just consume from your system.
+When executing the build step, Taopq will be built first, as its target is required by our application, after that, the example will be built too and linked to both libpq and Taopq.
+
+If you want to use `libpq` from your system, there are few ways to install it:
+
+* Linux
+    * Ubuntu: `$ sudo apt-get install libpq-dev postgresql-server-dev-all`
+    * Arch: `$ sudo pacman -S postgresql-libs`
+    * Fedora: `$ sudo dnf install libpq-devel`
+
+* Mac
+   * OSX: `$ brew install libpq`
+
+* Windows
+   * Windows 10: See PostgreSQL installation [page](https://www.postgresql.org/docs/7.2/install-win32.html)

--- a/doc/Installing.md
+++ b/doc/Installing.md
@@ -1,6 +1,6 @@
 # Installing
 
-The Taopq project is a library, different from other Taocpp projects, this one needs to be built and requires PostgreSQL library installed. On this section will visit some ways how to install Taopq properly. We will use CMake for building, but it does not mean that is the only way.
+The Taopq project is a library, different from other Taocpp projects, this one needs to be built and requires PostgreSQL library installed. On this section we will visit some ways how to install Taopq properly. We will use CMake for building.
 
 ## Using Conan package manager
 
@@ -25,7 +25,7 @@ Now, to install Taopq and its dependencies, run:
 
     conan install .
 
-Where `.` indicated the folder where `conanfile.txt` is installed. You also can pass the file path if you prefer.
+Where `.` indicates the folder where `conanfile.txt` is installed. You also can pass the file path instead.
 
 However, if you do not want to keep a new file, you can simply install the package directly, the result will be the same:
 
@@ -52,13 +52,13 @@ Now, we just need to configure and build our project:
     cmake .
     cmake --build .
 
-Done, your project should be built correctly and linked to Taopq, libpq and libz.
+Once done, your project should be built correctly and linked to Taopq, libpq and libz.
 
 
 ## Using CMake
 
-Since CMake 3.11, the feature [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) can used to download and build project dependencies.
-This mechanism makes our development much easier, but is lacks in terms of reproducibility, so be careful if you are using it for production. Also, we will use `FetchContent_MakeAvailable` which is available since CMake 3.14:
+Since CMake 3.11, the feature [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) can be used to download and build project dependencies.
+This mechanism makes our development much easier, but it lacks in terms of reproducibility, so be careful if you are using it for production. Also, we will use `FetchContent_MakeAvailable` which is available since CMake 3.14:
 
 ```cmake
 cmake_minimum_required(VERSION 3.14)
@@ -86,8 +86,8 @@ Now, we just need to execute CMake as usual:
     cmake --build .
 
 The CMake client will download Taopq source files based on the `main` branch, but is highly recommended using a commit to keep the reproducibility.
-Besides that, PostgreSQL (libpq) is a pre-requirement. You can extend your CMake to download and build libpq too, or just consume from your system.
-When executing the build step, Taopq will be built first, as its target is required by our application, after that, the example will be built too and linked to both libpq and Taopq.
+Besides that, PostgreSQL (libpq) is a pre-requirement. You can extend the `CMakeLists.txt` to download and build libpq too, or just consume from your system.
+When executing the build step, Taopq will be built first, as its target is required by our application, after that, the example application will be built and linked to both libpq and Taopq.
 
 If you want to use `libpq` from your system, there are few ways to install it:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,7 @@
  * [Project](https://github.com/taocpp/taopq)
  * [Overview](Overview.md)
    * [Important](Overview.md#important)
- * Installing and Using - TODO
+ * [Installing](Installing.md)
  * [General](General.md)
    * [Connections](General.md#connections)
    * [Transactions](General.md#transactions)


### PR DESCRIPTION
This PR brings the basic process how to install Taopq. It's different from other projects because is not a header-only and requires PostgreSQL.

I listed only support based on CMake here, but we can expand in the future if requested.


/cc @SquirrelCZE

closes #40