### PR TITLE
Fix table writer with column type BYTEA

### DIFF
--- a/include/tao/pq/parameter_traits.hpp
+++ b/include/tao/pq/parameter_traits.hpp
@@ -22,6 +22,7 @@
 #include <tao/pq/null.hpp>
 #include <tao/pq/oid.hpp>
 
+
 namespace tao::pq
 {
    namespace internal


### PR DESCRIPTION
Fixes #50  
Add double backlash to escape the hex sequence and fixed what is think was a bug in the hex index calculations? Before the changes postgres did not interpret the hex-sequence as bytes so it would write the literal hex sequence to the database.  

Before changing  the following code gave different results when using INSERT vs COPY, after the path the output is the same. 


```C++
    auto conn = create_db_conn()
    conn->execute("DROP TABLE IF EXISTS test_table;");
    conn->execute("CREATE TABLE test_table (  buffer_bytes BYTEA NOT NULL);");


    const unsigned char bdata[] = { 'v', 255, 0, 'a', 1, 'b', 0 };
    
    conn->execute( "INSERT INTO test_table VALUES ( $1 )", tao::pq::to_binary_view(bdata) );

  
    tao::pq::table_writer tw(conn->direct(), "COPY test_table ( buffer_bytes ) FROM STDIN");
    tw.insert(tao::pq::to_binary_view(bdata));   
    tw.commit();
    



    const auto result_0 = conn->execute( "SELECT * FROM test_table" )[ 0 ][ 0 ].as< std::basic_string<unsigned char > >();
    const auto result_1 = conn->execute( "SELECT * FROM test_table" )[ 1 ][ 0 ].as< std::basic_string<unsigned char > >();
    fmt::print("result_0 = {}\n", fmt::join(result_0, ", ")); // result_0 = 118, 255, 0, 97, 1, 98, 0
    fmt::print("result_1 = {}\n", fmt::join(result_1, ", ")); // result_1 = 125, 48, 48, 48, 48, 54, 55, 48, 49, 54, 56, 48, 48
```