### PR TITLE
Make ${PostgreSQL_INCLUDE_DIRS} private to avoid unintentionally accessing PostgreSQL's headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ target_include_directories(taopq
   PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    ${PostgreSQL_INCLUDE_DIRS}
   PRIVATE
+    ${PostgreSQL_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 

--- a/src/test/pq/CMakeLists.txt
+++ b/src/test/pq/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB testsources *.cpp)
 foreach(testsourcefile ${testsources})
   get_filename_component(exename taopq-test-${testsourcefile} NAME_WE)
   add_executable(${exename} ${testsourcefile})
+  target_include_directories(taopq PRIVATE ${PostgreSQL_INCLUDE_DIRS})
   target_link_libraries(${exename} PRIVATE taocpp::taopq)
   set_target_properties(${exename} PROPERTIES
     CXX_STANDARD 17


### PR DESCRIPTION
fixes #52 