### PR TITLE
[hotfix] taopq requires ws2_32 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ target_include_directories(taopq
 )
 
 target_link_libraries(taopq PUBLIC ${PostgreSQL_LIBRARIES})
+if(WIN32)
+  target_link_libraries(taopq PUBLIC ws2_32)
+endif()
 
 target_compile_features(taopq PUBLIC cxx_std_17)
 


### PR DESCRIPTION
Both [WSAPoll](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll) and [WSAGetLastError](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsagetlasterror) are native Windows functions and implemented by `Ws2_32` library. 

Both functions are used by [Connection.cpp](https://github.com/taocpp/taopq/blob/4f05505e83630088d049039a499a591f66f1a56e/src/lib/pq/connection.cpp#L268) when building for Windows.

CMake does not injects that library automatically, when `winsock2.h` is listed, neither Windows compiler, so we need to add it manually.

fixes #64 