### PR TITLE
Use a separate network error type when polling fails because of a network error

### DIFF
--- a/include/tao/pq/exception.hpp
+++ b/include/tao/pq/exception.hpp
@@ -19,6 +19,12 @@ namespace tao::pq
       using std::runtime_error::runtime_error;
    };
 
+   struct network_error
+      : std::runtime_error
+   {
+      using std::runtime_error::runtime_error;
+   };
+
    // https://www.postgresql.org/docs/current/errcodes-appendix.html
    struct sql_error
       : std::runtime_error

--- a/src/lib/pq/connection.cpp
+++ b/src/lib/pq/connection.cpp
@@ -276,7 +276,7 @@ namespace tao::pq
 
             case 1:
                if( ( pfd.revents & events ) == 0 ) {
-                  throw std::runtime_error( internal::printf( "WSAPoll() failed, events %hd, revents %hd", events, pfd.revents ) );
+                  throw network_error( internal::printf( "WSAPoll() failed, events %hd, revents %hd", events, pfd.revents ) );
                }
                if( ( pfd.revents & POLLIN ) != 0 ) {
                   get_notifications();
@@ -305,7 +305,7 @@ namespace tao::pq
 
             case 1:
                if( ( pfd.revents & events ) == 0 ) {
-                  throw std::runtime_error( internal::printf( "poll() failed, events %hd, revents %hd", events, pfd.revents ) );  // LCOV_EXCL_LINE
+                  throw network_error( internal::printf( "poll() failed, events %hd, revents %hd", events, pfd.revents ) );  // LCOV_EXCL_LINE
                }
                if( ( pfd.revents & POLLIN ) != 0 ) {
                   get_notifications();


### PR DESCRIPTION
Currently when connection polling fails in WSAPoll/poll the library throws a generic std::runtime_error.
This happen in various cases including
- When the client keeps an open connection to the PostgreSQL server and the server is restarted. This causes the server to close the connection on its side, so when the client tries to read from the socket it gets POLLHUP (0x0002) or when it tries to write to the socket it gets POLLHUP | POLLERR (0x0003).
- When there is a network error, e.g. "no route to host", attempts to write to the socket cause POLLHUP | POLLERR (0x0003).

It makes sense to differentiate network errors like the above and internal errors caused by other reasons. For network errors some kind of retry mechanism could be used, while internal errors should probably cause program termination and/or a crash dump.

This pull request adds a separate network error type which is used when polling yields unexpected event flags, thus allowing differentiation between network error and internal errors.