### PR TITLE
Add a base exception for all taopq exceptions.

### DIFF
--- a/include/tao/pq/exception.hpp
+++ b/include/tao/pq/exception.hpp
@@ -13,21 +13,27 @@
 
 namespace tao::pq
 {
-   struct timeout_reached
+   struct base_error
       : std::runtime_error
    {
       using std::runtime_error::runtime_error;
    };
 
-   struct network_error
-      : std::runtime_error
+   struct timeout_reached
+      : base_error
    {
-      using std::runtime_error::runtime_error;
+      using base_error::base_error;
+   };
+
+   struct network_error
+      : base_error
+   {
+      using base_error::base_error;
    };
 
    // https://www.postgresql.org/docs/current/errcodes-appendix.html
    struct sql_error
-      : std::runtime_error
+      : base_error
    {
       std::string sqlstate;
 

--- a/src/lib/pq/exception.cpp
+++ b/src/lib/pq/exception.cpp
@@ -7,7 +7,7 @@
 namespace tao::pq
 {
    sql_error::sql_error( const char* what, const std::string_view in_sqlstate )
-      : std::runtime_error( what ),
+      : base_error( what ),
         sqlstate( in_sqlstate )
    {}
 


### PR DESCRIPTION
This PR adds a base_error exception type from which all the other exception types (timeout_reached, network_error, sql_error) derive. This allows catching all possible taopq exceptions with a single catch block. Earlier I suggested this change in https://github.com/taocpp/taopq/issues/68.