### PR TITLE
Fix build using Makefile and add a CI build to validate Make

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -149,3 +149,42 @@ jobs:
 
     - name: Run tests
       run: cmake --build --preset unixlike-release-dev --target test
+
+  linux-makefile:
+    runs-on: ubuntu-24.04
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      TAOPQ_TEST_DATABASE: host=localhost dbname=postgres user=postgres password=postgres
+      CXX: g++-13
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libpq-dev libc++-dev
+        version: 2.0
+
+    - name: Build project files with Makefile
+      run: make -j$(nproc)
+
+    - name: Run tests with Makefile
+      run: make test
+      env:
+        PGDATABASE: ${{ env.TAOPQ_TEST_DATABASE }}

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 BUILDDIR ?= build
 
-INCFLAGS ?= -Iinclude $(patsubst %,-I%,$(shell pg_config --includedir))
+INCFLAGS ?= -Iinclude -Itest $(patsubst %,-I%,$(shell pg_config --includedir))
 CPPFLAGS ?= -pedantic
 CXXFLAGS ?= -Wall -Wextra -Wshadow -Werror -O3 $(MINGW_CXXFLAGS)
 LDFLAGS ?= -rdynamic $(patsubst %,-L%,$(shell pg_config --libdir))
@@ -44,10 +44,12 @@ CLANG_TIDY ?= clang-tidy
 
 HEADERS := $(shell find include -name '*.hpp')
 SOURCES := $(shell find src -name '*.cpp')
-DEPENDS := $(SOURCES:%.cpp=$(BUILDDIR)/%.d)
-BINARIES := $(SOURCES:%.cpp=$(BUILDDIR)/%)
+TESTSOURCES := $(shell find test -name '*.cpp')
+DEPENDS := $(SOURCES:%.cpp=$(BUILDDIR)/%.d) $(TESTSOURCES:%.cpp=$(BUILDDIR)/%.d)
+BINARIES := $(SOURCES:%.cpp=$(BUILDDIR)/%) $(TESTSOURCES:%.cpp=$(BUILDDIR)/%)
 
-UNIT_TESTS := $(filter $(BUILDDIR)/src/test/%,$(BINARIES))
+UNIT_TESTS := $(filter $(BUILDDIR)/test/unit/%,$(BINARIES))
+INTEGRATION_TESTS := $(filter $(BUILDDIR)/test/integration/%,$(BINARIES))
 
 LIBSOURCES := $(filter src/lib/%,$(SOURCES))
 LIBNAME := taopq


### PR DESCRIPTION
Hi! This PR addresses https://github.com/taocpp/taopq/pull/84#issuecomment-4306887185

The previous PR #84 changed the project structure, which affected not only the CMakeLists.txt, but also compromised the Makefile, resulting in missing include folders, which does not break the build, but ends silently:

```
CC=/usr/bin/gcc-13 CXX=/usr/bin/g++-13 make

/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/table_field.d src/lib/pq/table_field.cpp -o build/src/lib/pq/table_field.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/result_traits.d src/lib/pq/result_traits.cpp -o build/src/lib/pq/result_traits.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/transaction_base.d src/lib/pq/transaction_base.cpp -o build/src/lib/pq/transaction_base.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/field.d src/lib/pq/field.cpp -o build/src/lib/pq/field.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/result.d src/lib/pq/result.cpp -o build/src/lib/pq/result.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/row.d src/lib/pq/row.cpp -o build/src/lib/pq/row.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/parameter_traits.d src/lib/pq/parameter_traits.cpp -o build/src/lib/pq/parameter_traits.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/table_reader.d src/lib/pq/table_reader.cpp -o build/src/lib/pq/table_reader.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/connection.d src/lib/pq/connection.cpp -o build/src/lib/pq/connection.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/connection_pool.d src/lib/pq/connection_pool.cpp -o build/src/lib/pq/connection_pool.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/table_row.d src/lib/pq/table_row.cpp -o build/src/lib/pq/table_row.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/table_writer.d src/lib/pq/table_writer.cpp -o build/src/lib/pq/table_writer.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/transaction.d src/lib/pq/transaction.cpp -o build/src/lib/pq/transaction.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/exception.d src/lib/pq/exception.cpp -o build/src/lib/pq/exception.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/result_traits_array.d src/lib/pq/result_traits_array.cpp -o build/src/lib/pq/result_traits_array.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/internal/demangle.d src/lib/pq/internal/demangle.cpp -o build/src/lib/pq/internal/demangle.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/internal/poll.d src/lib/pq/internal/poll.cpp -o build/src/lib/pq/internal/poll.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/internal/strtox.d src/lib/pq/internal/strtox.cpp -o build/src/lib/pq/internal/strtox.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/pipeline.d src/lib/pq/pipeline.cpp -o build/src/lib/pq/pipeline.d
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -MM -MQ build/src/lib/pq/large_object.d src/lib/pq/large_object.cpp -o build/src/lib/pq/large_object.d
```

By adding the commit 0760f221152078212f82508d5226d961d349de66, the build not works again, but run the unit tests as well:

```
CC=/usr/bin/gcc-13 CXX=/usr/bin/g++-13 make

/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c test/unit/strtox.cpp -o build/test/unit/strtox.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/large_object.cpp -o build/src/lib/pq/large_object.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/pipeline.cpp -o build/src/lib/pq/pipeline.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/internal/strtox.cpp -o build/src/lib/pq/internal/strtox.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/internal/poll.cpp -o build/src/lib/pq/internal/poll.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/internal/demangle.cpp -o build/src/lib/pq/internal/demangle.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/result_traits_array.cpp -o build/src/lib/pq/result_traits_array.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/exception.cpp -o build/src/lib/pq/exception.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/transaction.cpp -o build/src/lib/pq/transaction.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/table_writer.cpp -o build/src/lib/pq/table_writer.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/table_row.cpp -o build/src/lib/pq/table_row.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/connection_pool.cpp -o build/src/lib/pq/connection_pool.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/connection.cpp -o build/src/lib/pq/connection.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/table_reader.cpp -o build/src/lib/pq/table_reader.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/parameter_traits.cpp -o build/src/lib/pq/parameter_traits.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/row.cpp -o build/src/lib/pq/row.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/result.cpp -o build/src/lib/pq/result.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/field.cpp -o build/src/lib/pq/field.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/transaction_base.cpp -o build/src/lib/pq/transaction_base.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/result_traits.cpp -o build/src/lib/pq/result_traits.o
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c src/lib/pq/table_field.cpp -o build/src/lib/pq/table_field.o
ar -rcs build/lib/libtaopq.a build/src/lib/pq/large_object.o build/src/lib/pq/pipeline.o build/src/lib/pq/internal/strtox.o build/src/lib/pq/internal/poll.o build/src/lib/pq/internal/demangle.o build/src/lib/pq/result_traits_array.o build/src/lib/pq/exception.o build/src/lib/pq/transaction.o build/src/lib/pq/table_writer.o build/src/lib/pq/table_row.o build/src/lib/pq/connection_pool.o build/src/lib/pq/connection.o build/src/lib/pq/table_reader.o build/src/lib/pq/parameter_traits.o build/src/lib/pq/row.o build/src/lib/pq/result.o build/src/lib/pq/field.o build/src/lib/pq/transaction_base.o build/src/lib/pq/result_traits.o build/src/lib/pq/table_field.o
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -L/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/lib build/test/unit/strtox.o build/lib/libtaopq.a -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -o build/test/unit/strtox
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c test/unit/resize_uninitialized.cpp -o build/test/unit/resize_uninitialized.o
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -L/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/lib build/test/unit/resize_uninitialized.o build/lib/libtaopq.a -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -o build/test/unit/resize_uninitialized
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c test/unit/result_type.cpp -o build/test/unit/result_type.o
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -L/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/lib build/test/unit/result_type.o build/lib/libtaopq.a -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -o build/test/unit/result_type
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c test/unit/parameter_type.cpp -o build/test/unit/parameter_type.o
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -L/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/lib build/test/unit/parameter_type.o build/lib/libtaopq.a -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -o build/test/unit/parameter_type
/usr/bin/g++-13 -std=c++20 -Iinclude -Itest -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -c test/unit/getenv.cpp -o build/test/unit/getenv.o
/usr/bin/g++-13 -std=c++20 -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include -I/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/include  -L/home/uilian/.conan2/p/libpq2f534ef8fc93e/p/lib build/test/unit/getenv.o build/lib/libtaopq.a -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -lpq -lpgcommon -lpgcommon_shlib -lpgport -lpgport_shlib -lpthread -lm -o build/test/unit/getenv
build/test/unit/strtox
TEST [ ASSERT tao::pq::internal::strtof( "0" ) == 0 ] in [ test/unit/strtox.cpp:57 ]
TEST [ ASSERT tao::pq::internal::strtof( "1" ) == 1 ] in [ test/unit/strtox.cpp:58 ]
TEST [ ASSERT tao::pq::internal::strtof( "00" ) == 0 ] in [ test/unit/strtox.cpp:59 ]
TEST [ ASSERT tao::pq::internal::strtof( "01" ) == 1 ] in [ test/unit/strtox.cpp:60 ]
TEST [ ASSERT tao::pq::internal::strtof( "0." ) == 0 ] in [ test/unit/strtox.cpp:61 ]
TEST [ ASSERT tao::pq::internal::strtof( "1." ) == 1 ] in [ test/unit/strtox.cpp:62 ]
TEST [ ASSERT tao::pq::internal::strtof( "0.0" ) == 0 ] in [ test/unit/strtox.cpp:63 ]
TEST [ ASSERT tao::pq::internal::strtof( "1.0" ) == 1 ] in [ test/unit/strtox.cpp:64 ]
TEST [ ASSERT tao::pq::internal::strtof( "0.5" ) == .5 ] in [ test/unit/strtox.cpp:65 ]
TEST [ ASSERT tao::pq::internal::strtof( ".5" ) == .5 ] in [ test/unit/strtox.cpp:66 ]
TEST [ ASSERT tao::pq::internal::strtof( ".25" ) == .25 ] in [ test/unit/strtox.cpp:67 ]
TEST [ ASSERT tao::pq::internal::strtof( ".125" ) == .125 ] in [ test/unit/strtox.cpp:68 ]
TEST [ ASSERT tao::pq::internal::strtof( ".0625" ) == .0625 ] in [ test/unit/strtox.cpp:69 ]
TEST [ ASSERT tao::pq::internal::strtof( ".4375" ) == .4375 ] in [ test/unit/strtox.cpp:70 ]
TEST [ ASSERT tao::pq::internal::strtof( "-0" ) == 0 ] in [ test/unit/strtox.cpp:72 ]
TEST [ ASSERT tao::pq::internal::strtof( "-1" ) == -1 ] in [ test/unit/strtox.cpp:73 ]
TEST [ ASSERT tao::pq::internal::strtof( "-00" ) == 0 ] in [ test/unit/strtox.cpp:74 ]
TEST [ ASSERT tao::pq::internal::strtof( "-01" ) == -1 ] in [ test/unit/strtox.cpp:75 ]
TEST [ ASSERT tao::pq::internal::strtof( "-0." ) == 0 ] in [ test/unit/strtox.cpp:76 ]
TEST [ ASSERT tao::pq::internal::strtof( "-1." ) == -1 ] in [ test/unit/strtox.cpp:77 ]
TEST [ ASSERT tao::pq::internal::strtof( "-0.0" ) == 0 ] in [ test/unit/strtox.cpp:78 ]
TEST [ ASSERT tao::pq::internal::strtof( "-1.0" ) == -1 ] in [ test/unit/strtox.cpp:79 ]
TEST [ ASSERT tao::pq::internal::strtof( "-0.5" ) == -.5 ] in [ test/unit/strtox.cpp:80 ]
TEST [ ASSERT tao::pq::internal::strtof( "-.5" ) == -.5 ] in [ test/unit/strtox.cpp:81 ]
TEST [ ASSERT tao::pq::internal::strtof( "-.25" ) == -.25 ] in [ test/unit/strtox.cpp:82 ]
TEST [ ASSERT tao::pq::internal::strtof( "-.125" ) == -.125 ] in [ test/unit/strtox.cpp:83 ]
TEST [ ASSERT tao::pq::internal::strtof( "-.0625" ) == -.0625 ] in [ test/unit/strtox.cpp:84 ]
TEST [ ASSERT tao::pq::internal::strtof( "-.4375" ) == -.4375 ] in [ test/unit/strtox.cpp:85 ]
TEST [ ASSERT tao::pq::internal::strtof( "3.1415927410125732421875" ) == 3.1415927410125732421875 ] in [ test/unit/strtox.cpp:87 ]
TEST [ ASSERT tao::pq::internal::strtod( "3.1415927410125732421875" ) == 3.1415927410125732421875 ] in [ test/unit/strtox.cpp:88 ]
TEST [ ASSERT tao::pq::internal::strtold( "3.1415927410125732421875" ) == 3.1415927410125732421875 ] in [ test/unit/strtox.cpp:89 ]
TEST [ ASSERT tao::pq::internal::strtof( "0000000000000000000000000000000000000.0000000000000000000000000000000000000" ) == 0 ] in [ test/unit/strtox.cpp:91 ]
TEST [ ASSERT tao::pq::internal::strtof( "0000000000000000000000000000000000001.0000000000000000000000000000000000000" ) == 1 ] in [ test/unit/strtox.cpp:92 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "inf" ) ) ] in [ test/unit/strtox.cpp:94 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "INF" ) ) ] in [ test/unit/strtox.cpp:95 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "infinity" ) ) ] in [ test/unit/strtox.cpp:96 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "INFINITY" ) ) ] in [ test/unit/strtox.cpp:97 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "-inf" ) ) ] in [ test/unit/strtox.cpp:98 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "-INF" ) ) ] in [ test/unit/strtox.cpp:99 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "-infinity" ) ) ] in [ test/unit/strtox.cpp:100 ]
TEST [ ASSERT std::isinf( tao::pq::internal::strtof( "-INFINITY" ) ) ] in [ test/unit/strtox.cpp:101 ]
TEST [ ASSERT std::isnan( tao::pq::internal::strtof( "nan" ) ) ] in [ test/unit/strtox.cpp:102 ]
TEST [ ASSERT std::isnan( tao::pq::internal::strtof( "NaN" ) ) ] in [ test/unit/strtox.cpp:103 ]
TEST [ ASSERT std::isnan( tao::pq::internal::strtof( "NAN" ) ) ] in [ test/unit/strtox.cpp:104 ]
TEST [ ASSERT tao::pq::internal::strtof( "inf" ) > 0 ] in [ test/unit/strtox.cpp:106 ]
TEST [ ASSERT tao::pq::internal::strtof( "-inf" ) < 0 ] in [ test/unit/strtox.cpp:107 ]
build/test/unit/resize_uninitialized
TEST [ ASSERT s.size() == size ] in [ test/unit/resize_uninitialized.cpp:20 ]
TEST [ ASSERT s[ size ] == '\0' ] in [ test/unit/resize_uninitialized.cpp:21 ]
TEST [ ASSERT s[ 0 ] == 'h' ] in [ test/unit/resize_uninitialized.cpp:28 ]
TEST [ ASSERT s[ 1 ] == 'e' ] in [ test/unit/resize_uninitialized.cpp:29 ]
TEST [ ASSERT s.size() == size ] in [ test/unit/resize_uninitialized.cpp:20 ]
TEST [ ASSERT s[ size ] == '\0' ] in [ test/unit/resize_uninitialized.cpp:21 ]
TEST [ ASSERT s[ 0 ] == 'h' ] in [ test/unit/resize_uninitialized.cpp:32 ]
TEST [ ASSERT s[ 1 ] == 'e' ] in [ test/unit/resize_uninitialized.cpp:33 ]
TEST [ ASSERT s.size() == size ] in [ test/unit/resize_uninitialized.cpp:20 ]
TEST [ ASSERT s[ size ] == '\0' ] in [ test/unit/resize_uninitialized.cpp:21 ]
TEST [ ASSERT s[ 0 ] == 'h' ] in [ test/unit/resize_uninitialized.cpp:36 ]
TEST [ ASSERT s[ 1 ] == 'e' ] in [ test/unit/resize_uninitialized.cpp:37 ]
TEST [ ASSERT s.size() == size ] in [ test/unit/resize_uninitialized.cpp:20 ]
TEST [ ASSERT s[ size ] == '\0' ] in [ test/unit/resize_uninitialized.cpp:21 ]
TEST [ ASSERT s[ 0 ] == 'h' ] in [ test/unit/resize_uninitialized.cpp:40 ]
TEST [ ASSERT s[ 1 ] == 'e' ] in [ test/unit/resize_uninitialized.cpp:41 ]
TEST [ ASSERT s.size() == size ] in [ test/unit/resize_uninitialized.cpp:20 ]
TEST [ ASSERT s[ size ] == '\0' ] in [ test/unit/resize_uninitialized.cpp:21 ]
TEST [ ASSERT s[ 0 ] == 'h' ] in [ test/unit/resize_uninitialized.cpp:44 ]
TEST [ ASSERT s[ 1 ] == 'e' ] in [ test/unit/resize_uninitialized.cpp:45 ]
TEST [ ASSERT v.size() == 2 ] in [ test/unit/resize_uninitialized.cpp:48 ]
TEST [ ASSERT v[ 0 ] == static_cast< std::byte >( 42 ) ] in [ test/unit/resize_uninitialized.cpp:49 ]
TEST [ ASSERT v[ 1 ] == static_cast< std::byte >( 69 ) ] in [ test/unit/resize_uninitialized.cpp:50 ]
TEST [ ASSERT v.size() == 5 ] in [ test/unit/resize_uninitialized.cpp:53 ]
TEST [ ASSERT v[ 0 ] == static_cast< std::byte >( 42 ) ] in [ test/unit/resize_uninitialized.cpp:54 ]
TEST [ ASSERT v[ 1 ] == static_cast< std::byte >( 69 ) ] in [ test/unit/resize_uninitialized.cpp:55 ]
TEST [ ASSERT v.size() == 1000000000 ] in [ test/unit/resize_uninitialized.cpp:58 ]
TEST [ ASSERT v[ 0 ] == static_cast< std::byte >( 42 ) ] in [ test/unit/resize_uninitialized.cpp:59 ]
TEST [ ASSERT v[ 1 ] == static_cast< std::byte >( 69 ) ] in [ test/unit/resize_uninitialized.cpp:60 ]
TEST [ ASSERT v.size() == 2 ] in [ test/unit/resize_uninitialized.cpp:63 ]
TEST [ ASSERT v[ 0 ] == static_cast< std::byte >( 42 ) ] in [ test/unit/resize_uninitialized.cpp:64 ]
TEST [ ASSERT v[ 1 ] == static_cast< std::byte >( 69 ) ] in [ test/unit/resize_uninitialized.cpp:65 ]
build/test/unit/result_type
build/test/unit/parameter_type
build/test/unit/getenv
TEST [ ASSERT !tao::pq::internal::getenv( "PATH" ).empty() ] in [ test/unit/getenv.cpp:15 ]
TEST [ THROWS tao::pq::internal::getenv( "TAOPQ_DOESNOTEXIST" ) ] in [ test/unit/getenv.cpp:16 ]
TEST caught [ std::runtime_error ] with [ environment variable not found: TAOPQ_DOESNOTEXIST ] in [ test/unit/getenv.cpp:16 ]
TEST [ ASSERT !tao::pq::internal::getenv( "PATH", "" ).empty() ] in [ test/unit/getenv.cpp:18 ]
TEST [ ASSERT tao::pq::internal::getenv( "TAOPQ_DOESNOTEXIST", "" ).empty() ] in [ test/unit/getenv.cpp:19 ]
TEST [ ASSERT tao::pq::internal::getenv( "TAOPQ_DOESNOTEXIST", "DEFAULT VALUE" ) == "DEFAULT VALUE" ] in [ test/unit/getenv.cpp:20 ]
```


Regards! 