### PR TITLE
[infrastructure] Add GCC-15 and GCC-16 from ubuntu-toolchain-r

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,8 @@ jobs:
         compiler:
           - g++-13
           - g++-14
+          - g++-15
+          - g++-16
           - clang++-18
 
     runs-on: ubuntu-24.04
@@ -48,6 +50,20 @@ jobs:
       with:
         packages: libpq-dev libc++-dev
         version: 2.0
+
+    - name: Install GCC-15
+      if: matrix.compiler == 'g++-15'
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get update
+        sudo apt-get install -y g++-15
+
+    - name: Install GCC-16
+      if: matrix.compiler == 'g++-16'
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get update
+        sudo apt-get install -y g++-16
 
     - name: Configure CMake Project
       run: cmake --preset unixlike-release-dev -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/taopq-install


### PR DESCRIPTION
Hi! This PR adds both GCC-15 and GCC-16 to Linux builds using CMake :rocket: 

As the official Ubuntu image provided by Github Actions is based on 24.04: https://github.com/actions/runner-images, we can not have official gcc-15 installed due distro limitation: https://packages.ubuntu.com/search?keywords=gcc-15

As a workaround, we can pull from https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test?field.series_filter=noble which is not stable, but should break a leg for our case.

Regards! 